### PR TITLE
DEVOPS-4477: HubSpot workflow automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 node_modules
+.terraform
+terraform/lambda.zip

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+  backend "s3" {
+    bucket         = "finix-terraform-qa"
+    key            = "backend.tfstate"
+    region         = "us-west-2"
+    encrypt        = true
+    use_lockfile   = true
+    assume_role = {
+      role_arn = "arn:aws:iam::830706739344:role/terraform-admin"
+    }
+  }
+}
+
+module "environment" {
+  source    = "git@github.com:finix-payments/finix-terraform.git//aws/modules/constants/environments"
+  workspace = terraform.workspace
+}
+
+provider "aws" {
+  region = module.environment.values.region
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,15 @@
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/.." # repo root (one level up from infra/)
+  output_path = "${path.module}/lambda.zip"
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,96 @@
+# Basic role for Lambda to write CloudWatch Logs
+resource "aws_iam_role" "lambda_exec" {
+  name               = "${var.project_name}-lambda-exec"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "basic_logs" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# CloudWatch log group (optional but nice to precreate)
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.project_name}"
+  retention_in_days = 14
+}
+
+# The Lambda function
+resource "aws_lambda_function" "webhook" {
+  function_name = var.project_name
+  role          = aws_iam_role.lambda_exec.arn
+  filename      = data.archive_file.lambda_zip.output_path
+  source_code_hash = filebase64sha256(data.archive_file.lambda_zip.output_path)
+
+  runtime = var.nodejs_runtime
+
+  # Your request: set the handler to index.ProductEventHandler
+  handler = "index.productEventHandler"
+
+  timeout = 15
+  memory_size = 256
+
+  # Environment variable for the webhook
+  environment {
+    variables = {
+      SECRET_ID = aws_secretsmanager_secret.hubspot_api_token.name
+      NODE_ENV  = "production"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
+}
+
+resource "aws_apigatewayv2_api" "http_api" {
+  name          = "${var.project_name}-httpapi"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "lambda_proxy" {
+  api_id                 = aws_apigatewayv2_api.http_api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.webhook.arn
+  payload_format_version = "2.0"
+}
+
+# Route (adjust method/path if your provider requires a specific one)
+resource "aws_apigatewayv2_route" "route" {
+  api_id    = aws_apigatewayv2_api.http_api.id
+  route_key = "POST /webhook"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda_proxy.id}"
+}
+
+# Stage with auto-deploy so changes go live
+resource "aws_apigatewayv2_stage" "stage" {
+  api_id      = aws_apigatewayv2_api.http_api.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+# Permit API Gateway to invoke the Lambda
+resource "aws_lambda_permission" "allow_apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.webhook.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*"
+}
+
+data "aws_iam_policy_document" "lambda_secrets_access" {
+  statement {
+    sid     = "ReadHubspotApiToken"
+    effect  = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret"
+    ]
+    resources = [aws_secretsmanager_secret.hubspot_api_token.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_secrets_access" {
+  name   = "${var.project_name}-secrets-access"
+  role   = aws_iam_role.lambda_exec.id
+  policy = data.aws_iam_policy_document.lambda_secrets_access.json
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,12 @@
+output "webhook_url" {
+  description = "POST this URL for the webhook"
+  value       = "${aws_apigatewayv2_api.http_api.api_endpoint}/webhook"
+}
+
+output "lambda_name" {
+  value = aws_lambda_function.webhook.function_name
+}
+
+output "lambda_arn" {
+  value = aws_lambda_function.webhook.arn
+}

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,5 @@
+# After this is created, get the api token from hubspot and add it in AWS
+resource "aws_secretsmanager_secret" "hubspot_api_token" {
+  name        = "hubspot/api-token" # no spaces allowed in names
+  description = "HubSpot webhook API token for Lambda"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable project_name {
+  description = "The name of the project, used for naming resources."
+  type        = string
+  default     = "revpartners-hubspot-automation"
+}
+
+variable nodejs_runtime {
+  description = "The Node.js runtime version for the Lambda function."
+  type        = string
+  default     = "nodejs22.x"
+}


### PR DESCRIPTION
This repo was forked from code that RevPartners provided to automate HubSpot deals in response to product changes.  This change adds terraform to deploy this as a lambda function, and updates the code to use SecretsManager to retrieve the HubSpot API token.